### PR TITLE
fix: shorten service port names

### DIFF
--- a/backend.star
+++ b/backend.star
@@ -27,6 +27,7 @@ def run(plan, cfg):
     backend_exposed = cfg["COMMON"].get("backend_exposed", False)
     title = cfg["TITLE"]
     service_port = cfg["PORT"]
+    service_port_name = cfg["PORT_NAME"]
     service_name = cfg["NAME"]
     service_image = cfg["IMAGE"]
 
@@ -98,7 +99,7 @@ def run(plan, cfg):
         config=ServiceConfig(
             image=service_image,
             ports={
-                service_name: PortSpec(
+                service_port_name: PortSpec(
                     service_port, application_protocol="http", wait="1m"
                 ),
             },

--- a/config.star
+++ b/config.star
@@ -37,6 +37,7 @@ def get_config(args, db_host=None, get_db_configs=False):
             "IMAGE": IMAGE_BACKEND,
             "NAME": "bs-backend" + deployment_suffix,
             "PORT": args.get("blockscot_backend_port", 4004),
+            "PORT_NAME": "backend",
             "TITLE": TITLE,
         },
         "STATS": {
@@ -49,16 +50,19 @@ def get_config(args, db_host=None, get_db_configs=False):
             "IMAGE": IMAGE_STATS,
             "NAME": "bs-stats" + deployment_suffix,
             "PORT": 8050,
+            "PORT_NAME": "stats",
         },
         "VISUALIZE": {
             "IMAGE": IMAGE_VISUALIZE,
-            "NAME": "bs-visualize" + deployment_suffix,
+            "NAME": "visualize" + deployment_suffix,
             "PORT": 8050,
+            "PORT_NAME": "visualize",
         },
         "FRONTEND": {
             "IMAGE": IMAGE_FRONTEND,
             "NAME": "bs-frontend" + deployment_suffix,
             "PORT": args.get("blockscout_public_port", 8000),
+            "PORT_NAME": "frontend",
             "IP": args.get("blockscout_public_ip", None),
             "TITLE": TITLE,
         },

--- a/frontend.star
+++ b/frontend.star
@@ -6,6 +6,7 @@ def run(plan, cfg, stack_info):
     backend_exposed = cfg["COMMON"].get("backend_exposed", False)
 
     service_port = cfg["PORT"]
+    service_port_name = cfg["PORT_NAME"]
     service_ip = cfg["IP"]
     service_name = cfg["NAME"]
     service_image = cfg["IMAGE"]
@@ -48,7 +49,7 @@ def run(plan, cfg, stack_info):
         config=ServiceConfig(
             image=service_image,
             ports={
-                service_name: PortSpec(
+                service_port_name: PortSpec(
                     service_port, application_protocol="http", wait="30s"
                 ),
             },

--- a/stats.star
+++ b/stats.star
@@ -19,6 +19,7 @@ def run(plan, cfg, bs_connection_string):
     )
 
     service_port = cfg["PORT"]
+    service_port_name = cfg["PORT_NAME"]
     service_name = cfg["NAME"]
     service_image = cfg["IMAGE"]
 
@@ -27,7 +28,7 @@ def run(plan, cfg, bs_connection_string):
         config=ServiceConfig(
             image=service_image,
             ports={
-                service_name: PortSpec(
+                service_port_name: PortSpec(
                     service_port, application_protocol="http", wait="30s"
                 ),
             },

--- a/visualize.star
+++ b/visualize.star
@@ -2,13 +2,14 @@ def run(plan, cfg):
     service_name = cfg["NAME"]
     service_image = cfg["IMAGE"]
     service_port = cfg["PORT"]
+    service_port_name = cfg["PORT_NAME"]
 
     service = plan.add_service(
         name=service_name,
         config=ServiceConfig(
             image=service_image,
             ports={
-                service_name: PortSpec(service_port, application_protocol="http"),
+                service_port_name: PortSpec(service_port, application_protocol="http"),
             },
         ),
     )


### PR DESCRIPTION
This PR update the service port names for couple of Blockscout services because they are too long (> 15 characters).

![image](https://github.com/xavier-romero/kurtosis-blockscout/assets/28714795/ddb74e7c-834c-49c6-91f3-1cceaf4c9814)


![Screenshot 2024-06-14 at 15 16 05](https://github.com/xavier-romero/kurtosis-blockscout/assets/28714795/79145925-ba53-4073-8faf-995b3cb49413)

Resolves #4 
