### PR TITLE
chore: bump versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        args_file:
+          - configs/zkevm-cardona.yaml
+          - configs/zkevm-mainnet.yaml
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kurtosis
+        shell: bash
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+          kurtosis version
+          kurtosis analytics disable
+      
+      - name: Run Starlark
+        run: kurtosis run --enclave=test --args-file=${{ matrix.args_file }} .
+
+      - name: Dump enclave logs
+        if: failure()
+        run: kurtosis dump ./dump
+
+      - name: Generate archive name
+        if: failure()
+        run: |
+          file_name=$(basename "${{ matrix.args_file }}" ".yaml")
+          archive_name="dump_blockscout_${file_name}_${{ github.run_id }}"
+          echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
+          echo "Generated archive name: ${archive_name}"
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARCHIVE_NAME }}
+          path: ./dump

--- a/config.star
+++ b/config.star
@@ -2,11 +2,11 @@
 # https://docs.blockscout.com/for-developers/information-and-settings/env-variables
 DB_PORT = 5432
 TITLE = "Polygon CDK"
-IMAGE_POSTGRES = "postgres:16.2"
-IMAGE_BACKEND = "blockscout/blockscout-zkevm:6.5.0"
-IMAGE_STATS = "ghcr.io/blockscout/stats:main"
-IMAGE_VISUALIZE = "ghcr.io/blockscout/visualizer:main"
-IMAGE_FRONTEND = "ghcr.io/blockscout/frontend:v1.30.0"
+IMAGE_POSTGRES = "postgres:17.0"
+IMAGE_BACKEND = "blockscout/blockscout-zkevm:6.8.1"
+IMAGE_STATS = "ghcr.io/blockscout/stats:v2.1.1"
+IMAGE_VISUALIZE = "ghcr.io/blockscout/visualizer:v0.2.1"
+IMAGE_FRONTEND = "ghcr.io/blockscout/frontend:v1.35.0"
 
 
 def get_config(args, db_host=None, get_db_configs=False):

--- a/frontend.star
+++ b/frontend.star
@@ -19,30 +19,43 @@ def run(plan, cfg, stack_info):
 
     env_vars = {
         "PORT": str(service_port),
+        ## Blockchain configuration.
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#blockchain-parameters
         "NEXT_PUBLIC_NETWORK_NAME": title,
         "NEXT_PUBLIC_NETWORK_ID": str(chain_id),
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#rollup-chain
+        "NEXT_PUBLIC_ROLLUP_TYPE": "zkEvm",
+        "NEXT_PUBLIC_ROLLUP_L1_BASE_URL": l1_explorer,
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#transaction-interpretation
+        "NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER": "blockscout",
+        ## API configuration.
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#api-configuration
+        "NEXT_PUBLIC_API_PROTOCOL": "http",
         "NEXT_PUBLIC_API_HOST": api_host,
         "NEXT_PUBLIC_API_PORT": api_port,
-        "NEXT_PUBLIC_API_PROTOCOL": "http",
         "NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL": "ws",
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#blockchain-statistics
         "NEXT_PUBLIC_STATS_API_HOST": "http://{}:{}".format(
             stack_info["stats_host"], stack_info["stats_port"]
         ),
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#solidity-to-uml-diagrams
         "NEXT_PUBLIC_VISUALIZE_API_HOST": "http://{}:{}".format(
             stack_info["visualize_host"], stack_info["visualize_port"]
         ),
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#app-configuration
         "NEXT_PUBLIC_APP_PROTOCOL": "http",
         "NEXT_PUBLIC_APP_HOST": service_ip or "127.0.0.1",
         "NEXT_PUBLIC_APP_PORT": str(service_port),
         "NEXT_PUBLIC_USE_NEXT_JS_PROXY": "true",
+        ## Remove ads.
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#banner-ads
         "NEXT_PUBLIC_AD_BANNER_PROVIDER": "none",
+        # https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#text-ads
         "NEXT_PUBLIC_AD_TEXT_PROVIDER": "none",
-        "NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER": "blockscout",
-        "NEXT_PUBLIC_ROLLUP_TYPE": "zkEvm",
-        "NEXT_PUBLIC_ROLLUP_L1_BASE_URL": l1_explorer,
     }
     if swap_url:
-        env_vars["NEXT_PUBLIC_SWAP_BUTTON_URL"] = swap_url
+        swap_item = {"text": "Polygon zkEVM Bridge", "icon": "swap", "url": swap_url}
+        env_vars["NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS"] = json.encode([swap_item])
 
     service = plan.add_service(
         name=service_name,


### PR DESCRIPTION
## Description

- Bump blockscout images versions and remove deprecated env var.
- Add `test` workflow to make sure the deployment still works: https://github.com/leovct/kurtosis-blockscout/pull/1

<img width="837" alt="Screenshot 2024-10-08 at 15 05 46" src="https://github.com/user-attachments/assets/fb619326-095a-460a-b97a-ba64977807dd">

